### PR TITLE
feat: add zero-build typing game

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,0 +1,193 @@
+/* game.js: Typing game logic and word list. Vanilla ES module with requestAnimationFrame loop and localStorage persistence. Key decisions: pre-render next word for smoother updates and keep state scoped to avoid globals. */
+
+export const WORDS = [
+  // Easy words
+  'cat', 'dog', 'sun', 'moon', 'tree', 'sky', 'ai', 'ka', 'neko', 'inu', 'sora', 'hana',
+  // Medium words
+  'orange', 'guitar', 'sushi', 'ramen', 'kawaii', 'tokyo', 'sakura', 'sensei', 'samurai', 'river',
+  // Hard words
+  'javascript', 'responsibility', 'extraordinary', 'konnichiwa', 'arigatou', 'mountain', 'computer', 'keyboard', 'nihongo', 'generation'
+];
+
+const EASY = WORDS.slice(0, 12);
+const MEDIUM = WORDS.slice(12, 22);
+const HARD = WORDS.slice(22);
+
+const TIMER_DURATION = 60; // seconds
+const STORAGE_KEY = 'typing-game-stats';
+
+const state = {
+  running: false,
+  currentWord: '',
+  nextWord: '',
+  score: 0,
+  combo: 0,
+  correct: 0,
+  total: 0,
+  startTime: 0,
+  elapsed: 0,
+  timeLeft: TIMER_DURATION,
+  highScore: 0,
+  bestWPM: 0,
+  wpm: 0
+};
+
+const el = {};
+
+console.log('[QA] game.js loaded');
+console.assert(Array.isArray(WORDS) && WORDS.length > 0, '[QA] WORDS array should not be empty');
+try {
+  localStorage.setItem('tg-check', '1');
+  localStorage.removeItem('tg-check');
+  console.log('[QA] localStorage R/W works');
+} catch (e) {
+  console.warn('[QA] localStorage unavailable', e);
+}
+
+/**
+ * Return a random word based on elapsed time for difficulty ramp.
+ * @param {number} elapsed Seconds since game start.
+ * @returns {string}
+ */
+function pickWord(elapsed) {
+  const pool = elapsed < 20 ? EASY : elapsed < 40 ? MEDIUM : HARD;
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+/**
+ * Update statistics UI.
+ */
+function updateStats() {
+  el.time.textContent = Math.ceil(state.timeLeft);
+  el.score.textContent = state.score;
+  const minutes = state.elapsed / 60;
+  state.wpm = minutes > 0 ? Math.round(state.correct / minutes) : 0;
+  el.wpm.textContent = `${state.wpm} WPM`;
+  const accuracy = state.total > 0 ? Math.round((state.correct / state.total) * 100) : 100;
+  el.accuracy.textContent = `${accuracy}%`;
+  el.combo.textContent = `${state.combo}x`;
+  el.highScore.textContent = `HS:${state.highScore}`;
+}
+
+function showWords() {
+  el.currentWord.textContent = state.currentWord;
+  el.nextWord.textContent = state.nextWord;
+}
+
+function flashError() {
+  el.wordContainer.classList.add('error');
+  setTimeout(() => el.wordContainer.classList.remove('error'), 300);
+}
+
+function handleKey(e) {
+  if (e.key === ' ' || e.key === 'Enter') {
+    e.preventDefault();
+    validateInput();
+  }
+}
+
+function validateInput() {
+  const value = el.input.value.trim();
+  state.total++;
+  if (value === state.currentWord) {
+    state.correct++;
+    state.score++;
+    state.combo++;
+    state.currentWord = state.nextWord;
+    state.nextWord = pickWord(state.elapsed);
+    showWords();
+  } else {
+    state.combo = 0;
+    flashError();
+  }
+  el.input.value = '';
+  updateStats();
+  el.input.focus();
+}
+
+function tick(now) {
+  state.elapsed = (now - state.startTime) / 1000;
+  state.timeLeft = Math.max(0, TIMER_DURATION - state.elapsed);
+  updateStats();
+  if (state.timeLeft > 0) {
+    requestAnimationFrame(tick);
+  } else {
+    endGame();
+  }
+}
+
+/**
+ * Initialize state and begin a new round.
+ */
+function startGame() {
+  state.running = true;
+  state.score = 0;
+  state.combo = 0;
+  state.correct = 0;
+  state.total = 0;
+  state.startTime = performance.now();
+  state.elapsed = 0;
+  state.timeLeft = TIMER_DURATION;
+
+  state.currentWord = pickWord(0);
+  state.nextWord = pickWord(0);
+  showWords();
+
+  el.start.classList.add('hidden');
+  el.game.classList.remove('hidden');
+  el.input.focus();
+  requestAnimationFrame(tick);
+}
+
+/**
+ * Finish the game, persist high scores, and show restart UI.
+ */
+function endGame() {
+  state.running = false;
+  el.restart.classList.remove('hidden');
+  el.input.blur();
+  if (state.score > state.highScore) state.highScore = state.score;
+  if (state.wpm > state.bestWPM) state.bestWPM = state.wpm;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ highScore: state.highScore, bestWPM: state.bestWPM }));
+  updateStats();
+}
+
+function loadStored() {
+  const data = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+  state.highScore = data.highScore || 0;
+  state.bestWPM = data.bestWPM || 0;
+}
+
+function init() {
+  el.start = document.getElementById('start');
+  el.restart = document.getElementById('restart');
+  el.game = document.getElementById('game');
+  el.input = document.getElementById('input');
+  el.currentWord = document.getElementById('current-word');
+  el.nextWord = document.getElementById('next-word');
+  el.time = document.getElementById('time');
+  el.score = document.getElementById('score');
+  el.wpm = document.getElementById('wpm');
+  el.accuracy = document.getElementById('accuracy');
+  el.combo = document.getElementById('combo');
+  el.highScore = document.getElementById('high-score');
+  el.wordContainer = document.getElementById('word-container');
+
+  loadStored();
+  updateStats();
+
+  el.start.addEventListener('click', startGame);
+  el.restart.addEventListener('click', () => {
+    el.restart.classList.add('hidden');
+    startGame();
+  });
+  el.input.addEventListener('keydown', handleKey);
+  el.input.addEventListener('blur', () => {
+    if (state.running) setTimeout(() => el.input.focus(), 0);
+  });
+  document.addEventListener('click', () => {
+    if (state.running) el.input.focus();
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!-- index.html: Main page for zero-build typing game using plain HTML/CSS/JS. Emphasizes accessibility, no-build setup, and no-JS fallback. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Typing Sprint</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main>
+    <h1>Typing Sprint</h1>
+    <p id="description">Type the word shown and press space or enter to submit. You have 60 seconds to score as many points as possible.</p>
+    <div id="game" class="hidden" aria-live="polite">
+      <div id="word-container">
+        <span id="current-word"></span>
+        <span id="next-word" aria-hidden="true"></span>
+      </div>
+      <label for="input" class="visually-hidden">Type the current word</label>
+      <input id="input" type="text" autocomplete="off" spellcheck="false" aria-label="Type the current word" />
+      <div id="stats">
+        <span id="time">60</span>s
+        <span id="score">0</span> pts
+        <span id="wpm">0 WPM</span>
+        <span id="accuracy">100%</span>
+        <span id="combo">0x</span>
+        <span id="high-score">HS:0</span>
+      </div>
+      <button id="restart">Restart</button>
+    </div>
+    <button id="start">Start</button>
+  </main>
+  <noscript>
+    <p>This game requires JavaScript. Typing the displayed words and submitting with space or enter scores points within 60 seconds.</p>
+  </noscript>
+  <script type="module" src="game.js"></script>
+
+  <!-- README: To customize the word list, edit the WORDS array in game.js. Adjust the timer length by changing the TIMER_DURATION constant in game.js. -->
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,82 @@
+/* styles.css: Core styles for the typing game. Mobile-first, high contrast, with focus and error animations. */
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: #fafafa;
+  color: #222;
+}
+
+main {
+  text-align: center;
+  width: 90%;
+  max-width: 600px;
+}
+
+#word-container {
+  font-size: 2rem;
+  margin: 1.5rem 0;
+}
+
+#next-word {
+  color: #bbb;
+  margin-left: 0.5rem;
+}
+
+input {
+  font-size: 1.5rem;
+  padding: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+#stats {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  font-size: 1rem;
+}
+
+button {
+  font-size: 1.25rem;
+  padding: 0.5rem 1rem;
+  margin-top: 1rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.error {
+  animation: shake 0.3s;
+}
+
+@keyframes shake {
+  0% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  50% { transform: translateX(5px); }
+  75% { transform: translateX(-5px); }
+  100% { transform: translateX(0); }
+}


### PR DESCRIPTION
## Summary
- implement vanilla JS typing game with mobile-friendly UI
- add styled layout and error feedback
- persist high scores locally and provide QA console checks

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc3ddaa0c88325a7d53b3c53eef88f