### PR TITLE
feat: refine typing game with practice mode and i18n

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,0 +1,282 @@
+/* game.js: Typing game logic. Imports locale data and manages modes, persistence, and UI updates. Key decisions: cache DOM writes, keep state encapsulated, and separate locale data. */
+
+import { LOCALES, DEFAULT_LOCALE } from './typing/data.js';
+
+const locale = LOCALES[DEFAULT_LOCALE];
+const { easy: EASY, medium: MEDIUM, hard: HARD } = locale.words;
+const ALL_WORDS = [...EASY, ...MEDIUM, ...HARD];
+
+const TIMER_DURATION = 60; // seconds
+const STORAGE_KEY = 'typing-game-stats';
+
+const state = {
+  running: false,
+  mode: 'timed',
+  currentWord: '',
+  nextWord: '',
+  score: 0,
+  combo: 0,
+  correct: 0,
+  total: 0,
+  startTime: 0,
+  elapsed: 0,
+  timeLeft: TIMER_DURATION,
+  highScore: 0,
+  bestWPM: 0,
+  wpm: 0,
+  history: []
+};
+
+const el = {};
+const prev = {};
+
+console.log('[QA] game.js loaded');
+console.assert(ALL_WORDS.length > 0, '[QA] word list should not be empty');
+try {
+  localStorage.setItem('tg-check', '1');
+  localStorage.removeItem('tg-check');
+  console.log('[QA] localStorage R/W works');
+} catch (e) {
+  console.warn('[QA] localStorage unavailable', e);
+}
+
+/**
+ * Return a random word based on difficulty ramp or practice mode.
+ * @returns {string}
+ */
+function pickWord() {
+  if (state.mode === 'practice') {
+    const pool = ALL_WORDS;
+    return pool[Math.floor(Math.random() * pool.length)];
+  }
+  const elapsed = state.elapsed;
+  const pool = elapsed < 20 ? EASY : elapsed < 40 ? MEDIUM : HARD;
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+/**
+ * Set text content if changed.
+ * @param {HTMLElement} node
+ * @param {string} value
+ * @param {string} key
+ */
+function setText(node, value, key) {
+  if (prev[key] !== value) {
+    node.textContent = value;
+    prev[key] = value;
+  }
+}
+
+/** Update statistics UI. */
+function updateStats() {
+  const accuracy = state.total > 0 ? Math.round((state.correct / state.total) * 100) : 100;
+  if (state.mode === 'timed') {
+    const minutes = state.elapsed / 60;
+    state.wpm = minutes > 0 ? Math.round(state.correct / minutes) : 0;
+    setText(el.time, `${Math.ceil(state.timeLeft)}${locale.ui.stats.time}`, 'time');
+    setText(el.score, `${state.score} ${locale.ui.stats.score}`, 'score');
+    setText(el.wpm, `${state.wpm} ${locale.ui.stats.wpm}`, 'wpm');
+    setText(el.accuracy, `${accuracy}${locale.ui.stats.accuracy}`, 'accuracy');
+    setText(el.combo, `${state.combo}${locale.ui.stats.combo}`, 'combo');
+    setText(el.highScore, `${locale.ui.stats.highScore}${state.highScore}`, 'high');
+  } else {
+    setText(el.accuracy, `${accuracy}${locale.ui.stats.accuracy}`, 'accuracy');
+    setText(el.combo, `${state.combo}${locale.ui.stats.streak}`, 'combo');
+  }
+}
+
+function showWords() {
+  el.currentWord.textContent = state.currentWord;
+  el.nextWord.textContent = state.nextWord;
+}
+
+function flashError() {
+  el.wordContainer.classList.add('error');
+  setTimeout(() => el.wordContainer.classList.remove('error'), 300);
+}
+
+function handleKey(e) {
+  if (e.key === ' ' || e.key === 'Enter') {
+    e.preventDefault();
+    validateInput();
+  }
+}
+
+function validateInput() {
+  const value = el.input.value.trim();
+  state.total++;
+  if (value === state.currentWord) {
+    state.correct++;
+    state.score++;
+    state.combo++;
+    state.currentWord = state.nextWord;
+    state.nextWord = pickWord();
+    showWords();
+  } else {
+    state.combo = 0;
+    flashError();
+  }
+  el.input.value = '';
+  updateStats();
+  el.input.focus();
+}
+
+function tick(now) {
+  state.elapsed = (now - state.startTime) / 1000;
+  state.timeLeft = Math.max(0, TIMER_DURATION - state.elapsed);
+  updateStats();
+  if (state.timeLeft > 0) {
+    requestAnimationFrame(tick);
+  } else {
+    endGame();
+  }
+}
+
+/** Start timed game. */
+function startGame() {
+  state.mode = 'timed';
+  state.running = true;
+  state.score = 0;
+  state.combo = 0;
+  state.correct = 0;
+  state.total = 0;
+  state.startTime = performance.now();
+  state.elapsed = 0;
+  state.timeLeft = TIMER_DURATION;
+
+  state.currentWord = pickWord();
+  state.nextWord = pickWord();
+  showWords();
+
+  el.menu.classList.add('hidden');
+  el.restart.classList.add('hidden');
+  el.game.classList.remove('hidden');
+  el.time.classList.remove('hidden');
+  el.score.classList.remove('hidden');
+  el.wpm.classList.remove('hidden');
+  el.highScore.classList.remove('hidden');
+  el.input.focus();
+  requestAnimationFrame(tick);
+}
+
+/** Start practice mode. */
+function startPractice() {
+  state.mode = 'practice';
+  state.running = true;
+  state.score = 0;
+  state.combo = 0;
+  state.correct = 0;
+  state.total = 0;
+
+  state.currentWord = pickWord();
+  state.nextWord = pickWord();
+  showWords();
+
+  el.menu.classList.add('hidden');
+  el.game.classList.remove('hidden');
+  el.restart.classList.remove('hidden');
+  el.restart.textContent = locale.ui.exit;
+  el.time.classList.add('hidden');
+  el.score.classList.add('hidden');
+  el.wpm.classList.add('hidden');
+  el.highScore.classList.add('hidden');
+  el.input.focus();
+}
+
+/** Finish timed game and persist stats. */
+function endGame() {
+  state.running = false;
+  el.restart.classList.remove('hidden');
+  el.restart.textContent = locale.ui.restart;
+  el.menu.classList.remove('hidden');
+  el.input.blur();
+  if (state.score > state.highScore) state.highScore = state.score;
+  if (state.wpm > state.bestWPM) state.bestWPM = state.wpm;
+  state.history.push({ score: state.score, wpm: state.wpm, ts: Date.now() });
+  if (state.history.length > 5) state.history = state.history.slice(-5);
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ highScore: state.highScore, bestWPM: state.bestWPM, history: state.history })
+  );
+  updateStats();
+  renderHistory();
+  el.restart.focus();
+}
+
+function exitPractice() {
+  state.running = false;
+  el.game.classList.add('hidden');
+  el.menu.classList.remove('hidden');
+  el.restart.classList.add('hidden');
+  el.input.blur();
+  el.start.focus();
+}
+
+/** Render last scores list. */
+function renderHistory() {
+  el.history.innerHTML = state.history
+    .map(
+      (h) =>
+        `<li>${new Date(h.ts).toLocaleTimeString()} - ${h.score} ${locale.ui.stats.score}, ${h.wpm} ${locale.ui.stats.wpm}</li>`
+    )
+    .join('');
+}
+
+function loadStored() {
+  const data = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+  state.highScore = data.highScore || 0;
+  state.bestWPM = data.bestWPM || 0;
+  state.history = Array.isArray(data.history) ? data.history : [];
+}
+
+function init() {
+  el.start = document.getElementById('start');
+  el.practice = document.getElementById('practice');
+  el.restart = document.getElementById('restart');
+  el.game = document.getElementById('game');
+  el.menu = document.getElementById('menu');
+  el.input = document.getElementById('input');
+  el.currentWord = document.getElementById('current-word');
+  el.nextWord = document.getElementById('next-word');
+  el.time = document.getElementById('time');
+  el.score = document.getElementById('score');
+  el.wpm = document.getElementById('wpm');
+  el.accuracy = document.getElementById('accuracy');
+  el.combo = document.getElementById('combo');
+  el.highScore = document.getElementById('high-score');
+  el.wordContainer = document.getElementById('word-container');
+  el.history = document.getElementById('history');
+  el.title = document.getElementById('title');
+  el.description = document.getElementById('description');
+
+  // apply locale strings
+  document.documentElement.lang = DEFAULT_LOCALE;
+  el.title.textContent = locale.ui.title;
+  el.description.textContent = locale.ui.description;
+  el.start.textContent = locale.ui.start;
+  el.practice.textContent = locale.ui.practice;
+  el.restart.textContent = locale.ui.restart;
+
+  loadStored();
+  updateStats();
+  renderHistory();
+
+  el.start.addEventListener('click', startGame);
+  el.practice.addEventListener('click', startPractice);
+  el.restart.addEventListener('click', () => {
+    if (state.mode === 'practice') {
+      exitPractice();
+    } else {
+      startGame();
+    }
+  });
+  el.input.addEventListener('keydown', handleKey);
+  el.input.addEventListener('blur', () => {
+    if (state.running) setTimeout(() => el.input.focus(), 0);
+  });
+  document.addEventListener('click', (e) => {
+    if (state.running && !e.target.closest('button')) el.input.focus();
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!-- index.html: Main page for zero-build typing game using plain HTML/CSS/JS. Emphasizes accessibility, no-build setup, and no-JS fallback. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Typing Sprint</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main>
+    <h1 id="title">Typing Sprint</h1>
+    <p id="description">Type the word shown and press space or enter to submit. You have 60 seconds to score as many points as possible.</p>
+    <div id="game" class="hidden">
+      <div id="word-container">
+        <span id="current-word" aria-live="assertive"></span>
+        <span id="next-word" aria-hidden="true"></span>
+      </div>
+      <label for="input" class="visually-hidden">Type the current word</label>
+      <input id="input" type="text" autocomplete="off" spellcheck="false" aria-label="Type the current word" />
+      <div id="stats">
+        <span id="time"></span>
+        <span id="score"></span>
+        <span id="wpm"></span>
+        <span id="accuracy"></span>
+        <span id="combo"></span>
+        <span id="high-score"></span>
+      </div>
+      <button id="restart" class="hidden">Restart</button>
+    </div>
+    <ul id="history" aria-label="Last scores"></ul>
+    <div id="menu">
+      <button id="start">Start</button>
+      <button id="practice">Practice</button>
+    </div>
+  </main>
+  <noscript>
+    <p>This game requires JavaScript. Typing the displayed words and submitting with space or enter scores points within 60 seconds.</p>
+  </noscript>
+  <script type="module" src="game.js"></script>
+
+  <!-- README: To customize word lists or UI strings, edit typing/data.js. Adjust the timer length by changing the TIMER_DURATION constant in game.js. -->
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,96 @@
+/* styles.css: Core styles for the typing game. Mobile-first, high contrast, with focus and error animations. */
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: #fafafa;
+  color: #222;
+}
+
+main {
+  text-align: center;
+  width: 90%;
+  max-width: 600px;
+}
+
+#word-container {
+  font-size: 2rem;
+  margin: 1.5rem 0;
+}
+
+#next-word {
+  color: #bbb;
+  margin-left: 0.5rem;
+}
+
+input {
+  font-size: 1.5rem;
+  padding: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+#stats {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  font-size: 1rem;
+}
+
+#history {
+  margin-top: 1rem;
+  list-style: none;
+  padding: 0;
+  font-size: 0.9rem;
+}
+
+#menu {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+button {
+  font-size: 1.25rem;
+  padding: 0.5rem 1rem;
+  margin-top: 1rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.error {
+  animation: shake 0.3s;
+}
+
+@keyframes shake {
+  0% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  50% { transform: translateX(5px); }
+  75% { transform: translateX(-5px); }
+  100% { transform: translateX(0); }
+}

--- a/typing/README.md
+++ b/typing/README.md
@@ -1,0 +1,22 @@
+# Typing Game
+
+Minimal typing game for GitHub Pages. Works with plain HTML/CSS/JS, no build step.
+
+## Setup
+1. Fork or clone this repo.
+2. Serve the directory through GitHub Pages or any static host.
+3. Open `index.html` in a modern browser.
+
+## Customization
+- **Word lists & UI strings:** edit `typing/data.js` for each locale.
+- **Timer length:** adjust `TIMER_DURATION` in `game.js`.
+- **Practice mode:** available via the *Practice* button; stats reset when exiting.
+
+## Troubleshooting
+- If stats do not persist, ensure the browser allows `localStorage`.
+- Mobile keyboards may blur the input; tap the background to refocus.
+- Use a modern browser; ES modules are required.
+
+## CHANGELOG
+- Added locale data module and practice mode.
+- Persist and display last five scores.

--- a/typing/data.js
+++ b/typing/data.js
@@ -1,0 +1,55 @@
+/* data.js: Locale map for words and UI strings. Enables simple internationalization.
+   Key decisions: keep data minimal and structured per-locale for zero-build environments. */
+
+export const LOCALES = {
+  en: {
+    words: {
+      easy: ['cat', 'dog', 'sun', 'moon', 'tree', 'sky', 'ai', 'ka', 'neko', 'inu', 'sora', 'hana'],
+      medium: ['orange', 'guitar', 'sushi', 'ramen', 'kawaii', 'tokyo', 'sakura', 'sensei', 'samurai', 'river'],
+      hard: ['javascript', 'responsibility', 'extraordinary', 'konnichiwa', 'arigatou', 'mountain', 'computer', 'keyboard', 'nihongo', 'generation']
+    },
+    ui: {
+      title: 'Typing Sprint',
+      description: 'Type the word shown and press space or enter to submit. You have 60 seconds to score as many points as possible.',
+      start: 'Start',
+      practice: 'Practice',
+      restart: 'Restart',
+      exit: 'Exit',
+      stats: {
+        time: 's',
+        score: 'pts',
+        wpm: 'WPM',
+        accuracy: '%',
+        combo: 'x',
+        highScore: 'HS:',
+        streak: 'x'
+      }
+    }
+  },
+  ja: {
+    words: {
+      easy: ['ねこ', 'いぬ', 'そら', 'はな'],
+      medium: ['さくら', 'すし', 'らーめん'],
+      hard: ['こんにちは', 'ありがとう', 'パソコン']
+    },
+    ui: {
+      title: 'タイピングスプリント',
+      description: '表示された単語を入力し、スペースまたはエンターで送信します。60秒でできるだけ多く入力しましょう。',
+      start: 'スタート',
+      practice: '練習',
+      restart: 'リスタート',
+      exit: '終了',
+      stats: {
+        time: '秒',
+        score: '点',
+        wpm: 'WPM',
+        accuracy: '%',
+        combo: '連',
+        highScore: '最高:',
+        streak: '連'
+      }
+    }
+  }
+};
+
+export const DEFAULT_LOCALE = 'en';


### PR DESCRIPTION
## Summary
- review fixes: improve focus management, restrict refocus listener, and localize UI strings
- add practice mode without timer and show last five scores with timestamps
- extract locale data to `typing/data.js` and document setup/customization in `typing/README.md`

## Testing
- `node --check game.js`
- `node --check typing/data.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc3ddaa0c88325a7d53b3c53eef88f